### PR TITLE
fix: 카카오 OAuth 인증 후 사용자 정보 대신 JWT 토큰 반환

### DIFF
--- a/src/main/java/com/world/planner/auth/application/KakaoAuthService.java
+++ b/src/main/java/com/world/planner/auth/application/KakaoAuthService.java
@@ -2,6 +2,7 @@ package com.world.planner.auth.application;
 
 import com.world.planner.auth.domain.KakaoUser;
 import com.world.planner.auth.infrastructure.KakaoApiClient;
+import com.world.planner.global.config.JwtTokenProvider;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,11 +13,22 @@ public class KakaoAuthService {
 
   private final KakaoApiClient kakaoApiClient;
 
-  public KakaoUser authenticateKakaoUser(String code) {
+  private final JwtTokenProvider jwtTokenProvider;
+
+  /**
+   * 카카오 OAuth 인증 코드를 사용하여 JWT 토큰을 생성합니다.
+   *
+   * @param code 카카오 OAuth 인증을 통해 발급된 인가 코드
+   * @return 생성된 JWT 토큰 문자열
+   */
+  public String generateJwtWithKakaoAuthCode(String code) {
     // Access Token 발급
     String accessToken = kakaoApiClient.getAccessToken(code);
 
     // 사용자 정보 가져오기
-    return kakaoApiClient.getUserInfo(accessToken);
+    KakaoUser user = kakaoApiClient.getUserInfo(accessToken);
+
+    // JWT 토큰 생성 후 반환
+    return jwtTokenProvider.createToken(user.getId());
   }
 }

--- a/src/main/java/com/world/planner/auth/presentation/KakaoAuthRestController.java
+++ b/src/main/java/com/world/planner/auth/presentation/KakaoAuthRestController.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,17 +18,17 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Kakao Authentication", description = "카카오 로그인 및 사용자 인증 API")
 @RestController
 @RequestMapping("/auth/kakao")
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class KakaoAuthRestController {
 
   private final KakaoAuthService kakaoAuthService;
 
   @Operation(
       summary = "카카오 로그인 콜백 처리",
-      description = "카카오 OAuth 인증 과정에서 발급된 인가 코드를 사용하여 사용자 인증을 처리합니다."
+      description = "카카오 OAuth 인증 과정에서 발급된 인가 코드를 사용하여 사용자 인증을 처리한 후 JWT 토큰을 반환합니다."
   )
   @ApiResponses({
-      @ApiResponse(responseCode = "200", description = "카카오 사용자 인증 성공"),
+      @ApiResponse(responseCode = "200", description = "카카오 사용자 인증 및 JWT 발급 성공"),
       @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 인가 코드 누락)"),
       @ApiResponse(responseCode = "500", description = "서버 오류")
   })
@@ -35,7 +37,6 @@ public class KakaoAuthRestController {
       @Parameter(description = "카카오 OAuth 인증을 통해 발급된 인가 코드", required = true)
       @RequestParam("code") String code
   ) {
-    // TODO JWT 기능 추가
-    return ResponseEntity.ok(kakaoAuthService.authenticateKakaoUser(code));
+    return ResponseEntity.ok(Map.of("token", kakaoAuthService.generateJwtWithKakaoAuthCode(code)));
   }
 }

--- a/src/main/java/com/world/planner/global/config/JwtTokenProvider.java
+++ b/src/main/java/com/world/planner/global/config/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import java.util.UUID;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -16,19 +17,39 @@ public class JwtTokenProvider {
   private String secretKey;
 
   /**
-   * 이메일 기반 JWT 토큰 생성
+   * ID 기반 JWT 토큰을 생성합니다.
    *
-   * @param email 이메일 (JWT의 주체)
+   * @param id JWT의 subject로 사용될 id
    * @return 생성된 JWT 토큰 문자열
    */
-  public String createToken(String email) {
+  public String createToken(String id) {
     Key key = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.HS512.getJcaName());
 
     return Jwts.builder()
-        .setSubject(email)
+        .setSubject(id)
         .setIssuedAt(new Date())
         .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1시간 유효
         .signWith(key) // SecretKey 객체를 사용해 서명
         .compact();
+  }
+
+  /**
+   * UUID 기반 JWT 토큰을 생성합니다.
+   *
+   * @param id JWT의 subject로 사용될 UUID
+   * @return 생성된 JWT 토큰 문자열
+   */
+  public String createToken(UUID id) {
+    return createToken(id.toString());
+  }
+
+  /**
+   * Long 타입 ID를 기반으로 JWT 토큰을 생성합니다.
+   *
+   * @param id JWT의 subject로 사용될 Long 타입 id
+   * @return 생성된 JWT 토큰 문자열
+   */
+  public String createToken(Long id) {
+    return createToken(id.toString());
   }
 }

--- a/src/main/java/com/world/planner/member/application/MemberService.java
+++ b/src/main/java/com/world/planner/member/application/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
     });
 
     // 해당 회원 정보로 JWT 토큰 발급
-    return jwtTokenProvider.createToken(member.getEmail());
+    return jwtTokenProvider.createToken(member.getId());
   }
 
   /**


### PR DESCRIPTION
### 변경 내용
- 카카오 OAuth 인증 후 `KakaoUser` 객체를 리턴하던 기존 로직을 `JWT 토큰`을 반환하는 로직으로 수정했습니다.
- JWT 토큰 생성 메서드(`createToken`)는 신규 사용자 유형(Long, UUID)에 따라 확장성을 제공하고, 따로 처리합니다.
- `generateJwtWithKakaoAuthCode` 메서드 내에서 사용자 ID를 기반으로 JWT를 생성하고 이를 반환하도록 구현되었습니다.

### 주요 변경 사항
1. **KakaoAuthService.java**
   - 사용자 정보를 반환하던 메서드(`authenticateKakaoUser`)를 `generateJwtWithKakaoAuthCode`로 변경.
   - 인증 과정을 통해 획득한 사용자 ID 기반으로 JWT를 생성하도록 수정.
2. **JwtTokenProvider.java**
   - Long ID, UUID를 기반으로 한 두 가지의 `createToken` 메서드를 추가 및 구현.

### 테스트
- 카카오 인증 후 사용자 정보를 성공적으로 받아와 JWT 토큰을 생성 및 반환.

### 기타 참고 사항
- 프론트엔드 통합 시 반환된 JWT를 Authorization 헤더로 사용 가능.